### PR TITLE
Remove management assets from public-facing pages

### DIFF
--- a/.rubocop-shared.yml
+++ b/.rubocop-shared.yml
@@ -36,6 +36,15 @@ Style/ClassAndModuleChildren:
 Style/Documentation:
   Enabled: false
 
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    default: ()
+    '%i': '[]'
+    '%I': '[]'
+    '%r': '{}'
+    '%w': '[]'
+    '%W': '[]'
+
 Style/IfUnlessModifier:
   Enabled: false
 

--- a/app/views/layouts/hackathon_manager.html.haml
+++ b/app/views/layouts/hackathon_manager.html.haml
@@ -4,11 +4,11 @@
     %title= yield(:title) || Rails.configuration.hackathon['default_page_title']
     %meta{ charset: "utf-8" }
     %meta{ name:"viewport", content: "width=device-width, initial-scale=1" }
-    = stylesheet_link_tag "hackathon_manager/manage", media: "all"
+    = stylesheet_link_tag "hackathon_manager/core", media: "all"
     = csrf_meta_tags
 
   %body
     = render "layouts/sidebar"
     #main
       = yield
-    = javascript_include_tag "hackathon_manager/manage/application"
+    = javascript_include_tag "hackathon_manager/application"

--- a/lib/hackathon_manager/engine.rb
+++ b/lib/hackathon_manager/engine.rb
@@ -7,6 +7,7 @@ module HackathonManager
     initializer "hackathon_manager.assets.precompile" do |app|
       app.config.assets.precompile += %w[
         hackathon_manager/manage.css
+        hackathon_manager/core.css
         hackathon_manager/home.css
         hackathon_manager/vendor/*.js
         hackathon_manager/vendor/*.css


### PR DESCRIPTION
Turns out we were serving a ton of extra CSS & JS on pages where it wasn't necessary

Side note: we should standardize our naming convention for what's considered public-facing/base/"core" assets vs. management-only assets