### PR TITLE
 Add config for bus captain notes

### DIFF
--- a/app/views/bus_lists/show.html.haml
+++ b/app/views/bus_lists/show.html.haml
@@ -4,14 +4,13 @@
 
   %p Thank you for being a bus captain! Below is any information you may need about your passengers.
 
-  %ul
-    %li Only students on this list may board the bus. <strong>No exceptions</strong>- this is to ensure everyone goes through the application process & has signed RIT's waivers.
-    %li If a student was accepted but didn't RSVP or sign up for the bus, they can go to <strong>https://brickhack.io/rsvp</strong> to do so.
-    %li If any emergencies arise, call our travel director, <strong>Velizar Demirev</strong>, at <strong>(413) 221-2420</strong>.
-    %li
-      If you have any other questions, please feel free to email
-      = link_to "travel@codeRIT.org", "mailto:travel@codeRIT.org"
-      !
+  %p
+    If a student was accepted but didn't RSVP or sign up for the bus, they can go to
+    %strong= rsvp_url
+    to do so.
+
+  - if Rails.configuration.hackathon['bus_captain_notes']
+    = markdown(Rails.configuration.hackathon['bus_captain_notes'])
 
   %p
     %b Bus List Name:

--- a/app/views/mailer/_questions.html.erb
+++ b/app/views/mailer/_questions.html.erb
@@ -1,2 +1,0 @@
-<h3>Questions?</h3>
-<p>If you have any questions, please check out our <a href="https://brickhack.io/#faq" target="_blank">FAQ</a>. You can also email <a href="mailto:travel@codeRIT.org">travel@codeRIT.org</a> with travel-related questions, or <a href="mailto:hello@codeRIT.org">hello@codeRIT.org</a> with general questions.</p>

--- a/app/views/mailer/bus_captain_confirmation_email.html.erb
+++ b/app/views/mailer/bus_captain_confirmation_email.html.erb
@@ -9,4 +9,4 @@
 </p>
 <p>This will be the central source of truth for passengers &amp; bus information, in addition to anything you hear from our travel director.</p>
 <p>This also means your <strong>name, email, and phone number</strong> are visible to everyone riding the bus. This information is taken straight from your <%= Rails.configuration.hackathon['name'] %> application, so please make sure it is up to date! You can check this at <a href="https://brickhack.io/apply">https://brickhack.io/apply</a></p>
-<p>Again, thank you so much for being a bus captain! If you have any questions at all, feel free to reach out to <a href="mailto:travel@codeRIT.org">travel@codeRIT.org</a>. We can't wait to see you at <%= Rails.configuration.hackathon['name'] %>!</p>
+<p>Again, thank you so much for being a bus captain! If you have any questions at all, feel free to reach out. We can't wait to see you at <%= Rails.configuration.hackathon['name'] %>!</p>

--- a/app/views/mailer/rsvp_confirmation_email.html.erb
+++ b/app/views/mailer/rsvp_confirmation_email.html.erb
@@ -3,4 +3,3 @@
 <p><strong>If you can no longer attend, please let us know so we can open the spot to someone else. <a href="https://brickhack.io/rsvp/deny" target="_blank">I Can No Longer Attend &raquo;</a></strong></p>
 <h3>Meet Other Hackers</h3>
 <p>Join our <a href="https://www.facebook.com/groups/brickhack3attendees/" target="_blank">Facebook Group</a> to get in touch with other attendees. This will be the best way to find teammates if you don't have a team already!</p>
-<%= render 'questions' %>

--- a/test/dummy/config/hackathon.yml
+++ b/test/dummy/config/hackathon.yml
@@ -17,7 +17,7 @@ defaults: &defaults
   # thanks_for_applying: |
   #   Message that appears after completing an application. Supports markdown.
   # bus_captain_notes: |
-  #   Message that appers on the bus captain's bust list page. Supports markdown.
+  #   Message that appers on the bus captain's bus list page. Supports markdown.
 
 development:
   <<: *defaults

--- a/test/dummy/config/hackathon.yml
+++ b/test/dummy/config/hackathon.yml
@@ -16,6 +16,8 @@ defaults: &defaults
   #   Message that appears before signing up & applying. Supports markdown.
   # thanks_for_applying: |
   #   Message that appears after completing an application. Supports markdown.
+  # bus_captain_notes: |
+  #   Message that appers on the bus captain's bust list page. Supports markdown.
 
 development:
   <<: *defaults


### PR DESCRIPTION
In the future this should be a UI-configurable section. (#14)

Also remove BrickHack-specific notes from default email templates, which included the travel email address. This completely removes the need to specify a travel email address in the gem's configuration; the only places it would appear are in these now-configurable notes, or the already-customizable email templates.