### PR TITLE
Flexible recipient options for all schools & bus lists

### DIFF
--- a/app/models/message_recipient_query.rb
+++ b/app/models/message_recipient_query.rb
@@ -1,0 +1,61 @@
+class MessageRecipientQuery
+  attr_accessor :query
+  attr_accessor :type
+  attr_accessor :id
+  attr_accessor :model
+
+  def initialize(query, type, id, model)
+    @query = query
+    @type = type
+    @id = id
+    @model = model
+  end
+
+  def self.parse(query, model = nil)
+    # Format:
+    # model::ID
+    # model--modifier::ID
+    match = query.match(/(.*)::(\d*)/)
+    type = match[1]
+    id = match[2]
+
+    # Find the backing database model, ensuring the given ID exists for that model.
+    model_name = nil
+    case type
+    when "bus-list", "bus-list--applied", "bus-list--eligible"
+      model ||= BusList.find_by_id(id)
+      model_name = "Bus List"
+    when "school"
+      model ||= School.find_by_id(id)
+      model_name = "School"
+    else
+      raise "Unknown recipient query type: #{type.inspect} (in message recipient query: #{query.inspect}"
+    end
+    raise "Could not find #{model_name} with ID #{id.inspect} (in message recipient query: #{query.inspect}" if model.blank?
+
+    MessageRecipientQuery.new(
+      query,
+      type,
+      id,
+      model
+    )
+  end
+
+  def self.friendly_name(query, model = nil)
+    recipient_query = parse(query, model)
+    model = recipient_query.model
+
+    case recipient_query.type
+    when "bus-list"
+      "Bus List: #{model.name} (signed up for bus)"
+    when "bus-list--eligible"
+      "Bus List: #{model.name} (eligible, not signed up for bus)"
+    when "bus-list--applied"
+      "Bus List: #{model.name} (applied/not accepted)"
+    when "school"
+      "Confirmed or Accepted: #{model.name}"
+    else
+      raise "Unknown recipient query type: #{recipient_query.type.inspect} (in message recipient query: #{r.inspect}"
+    end
+  end
+end

--- a/app/views/manage/messages/_form.html.haml
+++ b/app/views/manage/messages/_form.html.haml
@@ -7,9 +7,9 @@
       = f.input :subject, hint: "All emails are from <pre>#{html_escape(Rails.configuration.hackathon['email_from'])}</pre>".html_safe
       = f.input :template, as: :select, collection: Message::POSSIBLE_TEMPLATES.map { |x| [x.titleize, x] }, include_blank: false
       - if @message.status == "drafted"
-        = f.input :recipients, as: :select, collection: Message::POSSIBLE_RECIPIENTS.invert, input_html: { class: "selectize", multiple: true }, hint: "Sent manually, in bulk"
+        = f.input :recipients, as: :select, collection: Message.possible_recipients, input_html: { class: "selectize", multiple: true,  }, hint: "Sent manually, in bulk", placeholder: "Type to search by school or type..."
       - else
-        = f.input :recipients, as: :select, collection: Message::POSSIBLE_RECIPIENTS.invert, input_html: { class: "selectize", multiple: true }, hint: "Cannot be edited once a message has been delivered", disabled: true
+        = f.input :recipients, as: :select, collection: Message.possible_recipients, input_html: { class: "selectize", multiple: true }, hint: "Cannot be edited once a message has been delivered", disabled: true
       = f.input :trigger, as: :select, collection: Message::POSSIBLE_TRIGGERS.invert, include_blank: "(no automatic trigger)", hint: "Sent automatically, to an individual applicant"
       = f.input :body, input_html: { rows: 10 }, hint: "Supports markdown and HTML"
 

--- a/db/migrate/20180118035548_convert_message_recipients_to_recipient_queries.rb
+++ b/db/migrate/20180118035548_convert_message_recipients_to_recipient_queries.rb
@@ -1,0 +1,36 @@
+class ConvertMessageRecipientsToRecipientQueries < ActiveRecord::Migration[5.1]
+  CONVERSION_MAPPING = {
+    "bus-list-cornell-bing"            => ["bus-list", 1],
+    "bus-list-buffalo"                 => ["bus-list", 2],
+    "bus-list-albany"                  => ["bus-list", 3],
+    "bus-list-cornell-bing-eligible"   => ["bus-list--eligible", 1],
+    "bus-list-buffalo-eligible"        => ["bus-list--eligible", 2],
+    "bus-list-albany-eligible"         => ["bus-list--eligible", 3],
+    "bus-list-cornell-bing-applied"    => ["bus-list--applied", 1],
+    "bus-list-buffalo-applied"         => ["bus-list--applied", 2],
+    "bus-list-albany-applied"          => ["bus-list--applied", 3],
+    "school-rit"                       => ["school", 2304],
+    "school-cornell"                   => ["school", 2164],
+    "school-binghamton"                => ["school", 5526],
+    "school-buffalo"                   => ["school", 2345],
+    "school-waterloo"                  => ["school", 5580],
+    "school-toronto"                   => ["school", 5539],
+    "school-umd-collegepark"           => ["school", 5543]
+  }.freeze
+
+  def up
+    Message.all.each do |message|
+      CONVERSION_MAPPING.to_a.each do |mapping|
+        old = mapping[0]
+        new_type = mapping[1][0]
+        new_id = mapping[1][1]
+
+        index = message.recipients.index(old)
+        next if index.nil?
+
+        message.recipients[index] = "#{new_type}::#{new_id}"
+        message.save!
+      end
+    end
+  end
+end

--- a/test/models/message_test.rb
+++ b/test/models/message_test.rb
@@ -17,6 +17,24 @@ class MessageTest < ActiveSupport::TestCase
   should allow_value("default").for(:template)
   should_not allow_value("foo").for(:template)
 
+  context "recipients_list" do
+    should "return human-readable list of basic recipients" do
+      message = build(:message, recipients: ['all', 'incomplete'])
+      assert_equal "Everyone, Incomplete Applications", message.recipients_list
+    end
+
+    should "return human-readable list of querying recipients" do
+      create(:school, id: 567, name: 'My School')
+      message = build(:message, recipients: ['accepted', 'school::567'])
+      assert_equal "Accepted Applications, Confirmed or Accepted: My School", message.recipients_list
+    end
+
+    should "return unknown for invalid recipients" do
+      message = build(:message, recipients: ['all', 'foo', 'incomplete'])
+      assert_equal "Everyone, (unknown), Incomplete Applications", message.recipients_list
+    end
+  end
+
   context "delivered?" do
     should "return false if delivered date is not set" do
       message = build(:message)


### PR DESCRIPTION
No longer restricted to hard-coded schools and bus list IDs

Also finally added tests for what is probably one of the most important background jobs: actually processing who to send mass email to.

Ultimately for monitoring & bug recovery, there should be a full log of every email that goes out (and who receives it). But tests are a good start.